### PR TITLE
Fix: u.b. in destructor

### DIFF
--- a/SpeedTest/ScanData.cpp
+++ b/SpeedTest/ScanData.cpp
@@ -34,7 +34,7 @@ ScanData::ScanData(std::string input) {
 
 ScanData::~ScanData()
 {
-	delete (data);
+	delete[] data;
 }
 
 void ScanData::print() {


### PR DESCRIPTION
Destructor now calls delete[] for an array created with new[]

Fixes #1 